### PR TITLE
added support for 'privacy' => true

### DIFF
--- a/BSQLQuery.php
+++ b/BSQLQuery.php
@@ -309,6 +309,24 @@ abstract class BSQLQuery {
   }
   
   #
+  # Determine whether a field is allowed
+  #
+  public function isAllowed($column) {
+  	global $wgBugzillaReports;
+  	if (!isset($wgBugzillaReports['privacy']) || !$wgBugzillaReports['privacy']) {
+  	  return TRUE;
+  	}
+
+    if ($column == 'work' || $column == 'remaining') {
+      if ($this->isRequired('to')) {
+      	$this->context->warn("Content of ".$column." column was hidden because assignee is used in the query and privacy mode is enabled.");
+      	return FALSE; 
+      }
+  	}
+    return TRUE;
+  }
+  
+  #
   # Convert date to nice words
   #
   private function getRadarFormat($value) {

--- a/BugzillaQuery.php
+++ b/BugzillaQuery.php
@@ -1,4 +1,6 @@
 <?php
+
+
 /**
  * A bugzilla query 
  */
@@ -626,7 +628,7 @@ class BugzillaQuery extends BSQLQuery {
         $sql.=", qaprofiles.realname as qa";
       }
     }
-    if ($this->isRequired("remaining")) {
+    if ($this->isRequired("remaining") && $this->isAllowed("remaining")) {
       $sql.=", remaining_time as remaining";
     }
     if ($this->isRequired("reopened")) {
@@ -664,7 +666,7 @@ class BugzillaQuery extends BSQLQuery {
     if ($this->isRequired("votes")) {
       $sql.=", votes";
     }
-    if ($this->isRequired("work")) {
+    if ($this->isRequired("work") && $this->isAllowed("work")) {
       $sql.=", SUM(longdescswork.work_time) as work";
     }
     #


### PR DESCRIPTION
In our not-for-profit organization we want to be transparent on the amount of time spent on a per task basis. But for privacy reason there must be no easy way to generate a report on a per person basis.

The attached patch adds support for privacy mode by removing the work-column if the assignee of a bug is used in the projection or condition of a query.

To enabled privacy mode, add

    $wgBugzillaReports = array(
      ...
      'privacy'     => "true"
    );

to LocalSettings.php

https://code.google.com/p/bugzillareports/issues/detail?id=62